### PR TITLE
LIBS-599 - Add appId from producer to metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 <dependency>
 	<groupId>com.avides.spring</groupId>
 	<artifactId>spring-rabbit</artifactId>
-	<version>2.0.0-RC1</version>
+	<version>2.0.0-RC2</version>
 </dependency>
 ```
 

--- a/README.md
+++ b/README.md
@@ -175,11 +175,11 @@ spring.rabbitmq.outbounds[1].routing-key=another.routingkey.one
 spring.rabbitmq.outbounds[1].connection-factory.bean-name=myConnectionFactoryOne
 ```
 
-Example for an implementation of a rabbitListener
+Example for an implementation of a SpringRabbitListener
 
 ```java
 @Component
-public class MyListener extends CountingRabbitListener<CoreData>
+public class MyListener extends AbstractSpringRabbitListener<CoreData>
 {
     @Autowired
     private MyService myService;
@@ -441,7 +441,7 @@ spring.rabbitmq.queues[0].listener.creation-enabled=false
 
 @NotBlank
 
-The name of the AbstractRabbitListener.
+The name of the SpringRabbitListener.
 
 ``` ini
 spring.rabbitmq.queues[0].listener.bean-name=myListener

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
   <groupId>com.avides.spring</groupId>
   <artifactId>spring-rabbit</artifactId>
-  <version>2.0.0-RC1</version>
+  <version>2.0.0-RC2</version>
 
   <name>spring-rabbit</name>
   <description>Makes configuring RabbitMQ for Spring Boot applications more comfortable</description>

--- a/src/main/java/com/avides/spring/rabbit/configuration/creator/ListenerCreator.java
+++ b/src/main/java/com/avides/spring/rabbit/configuration/creator/ListenerCreator.java
@@ -3,8 +3,8 @@ package com.avides.spring.rabbit.configuration.creator;
 import org.springframework.amqp.rabbit.connection.ConnectionFactory;
 import org.springframework.amqp.support.converter.MessageConverter;
 
-import com.avides.spring.rabbit.listener.ContextAwareRabbitListener;
 import com.avides.spring.rabbit.listener.RabbitListener;
+import com.avides.spring.rabbit.listener.SpringRabbitListener;
 import com.avides.spring.rabbit.listener.container.DefaultMessageListenerContainer;
 
 import lombok.AllArgsConstructor;
@@ -35,9 +35,9 @@ public class ListenerCreator implements Creator<DefaultMessageListenerContainer<
     @SuppressWarnings("unchecked")
     private void apppendListenerToContainer(DefaultMessageListenerContainer<Object> container, MessageConverter converter)
     {
-        if (listener instanceof ContextAwareRabbitListener<?>)
+        if (listener instanceof SpringRabbitListener<?>)
         {
-            container.setContextAwareListener((ContextAwareRabbitListener<Object>) listener, converter);
+            container.setSpringRabbitListener((SpringRabbitListener<Object>) listener, converter);
         }
         else if (listener instanceof RabbitListener<?>)
         {

--- a/src/main/java/com/avides/spring/rabbit/listener/AbstractCountingRabbitListener.java
+++ b/src/main/java/com/avides/spring/rabbit/listener/AbstractCountingRabbitListener.java
@@ -5,6 +5,10 @@ import org.springframework.context.annotation.Lazy;
 
 import io.micrometer.core.instrument.MeterRegistry;
 
+/**
+ * @deprecated use {@link AbstractSpringRabbitListener}, will be removed soon
+ */
+@Deprecated(forRemoval = true)
 public abstract class AbstractCountingRabbitListener
 {
     @Lazy

--- a/src/main/java/com/avides/spring/rabbit/listener/AbstractSpringRabbitListener.java
+++ b/src/main/java/com/avides/spring/rabbit/listener/AbstractSpringRabbitListener.java
@@ -3,6 +3,7 @@ package com.avides.spring.rabbit.listener;
 import org.springframework.amqp.core.MessageProperties;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Lazy;
+import org.springframework.util.StringUtils;
 
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tag;
@@ -68,7 +69,7 @@ public abstract class AbstractSpringRabbitListener<T> implements SpringRabbitLis
         if (meterRegistry != null)
         {
             var tags = Tags.of(Tag.of("listener", getClass().getSimpleName()));
-            if (messageProperties != null)
+            if (messageProperties != null && StringUtils.hasText(messageProperties.getAppId()))
             {
                 tags = tags.and(Tag.of("from", messageProperties.getAppId()));
             }

--- a/src/main/java/com/avides/spring/rabbit/listener/AbstractSpringRabbitListener.java
+++ b/src/main/java/com/avides/spring/rabbit/listener/AbstractSpringRabbitListener.java
@@ -1,0 +1,73 @@
+package com.avides.spring.rabbit.listener;
+
+import org.springframework.amqp.core.MessageProperties;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Lazy;
+
+import io.micrometer.core.instrument.MeterRegistry;
+
+/**
+ * Abstract implementation of {@link SpringRabbitListener} with metrics.
+ * <p>
+ * Implementing classes shall either override {@link #handleEvent(Object)} or {@link #handleEvent(Object, MessageProperties)}.
+ */
+public abstract class AbstractSpringRabbitListener<T> implements SpringRabbitListener<T>
+{
+    @Lazy
+    @Autowired
+    protected MeterRegistry meterRegistry;
+
+    /**
+     * Handles given unmarshaled message. Called by {@link #handleEvent(Object, MessageProperties)}
+     *
+     * @param object the unmarshaled object
+     */
+    protected void handleEvent(T object)
+    {
+        throw new UnsupportedOperationException("Implementation of AbstractSpringRabbitListener has to override one of the handleEvent methods");
+    }
+
+    /**
+     * Handles given unmarshaled message with its properties. Called by {@link #handle(Object, MessageProperties)} which also collects some metrics. Calls
+     * {@link #handleEvent(Object)} by default which may be overridden.
+     *
+     * @param object the unmarshaled object
+     * @param messageProperties the message properties
+     */
+    protected void handleEvent(T object, MessageProperties messageProperties)
+    {
+        handleEvent(object);
+    }
+
+    /**
+     * Handles given unmarshaled message with its properties and collects some metrics. Calls {@link #handleEvent(Object, MessageProperties)} by default which
+     * may be overridden.
+     * <p>
+     * Metrics are:
+     * <ul>
+     * <li>rabbit.listener.event
+     * <li>rabbit.listener.event.total.duration.milliseconds
+     * </ul>
+     *
+     * @param object the incoming object
+     * @param messageProperties the message properties of the message
+     */
+    @Override
+    public void handle(T object, MessageProperties messageProperties)
+    {
+        long started = System.currentTimeMillis();
+        handleEvent(object, messageProperties);
+        count(started);
+    }
+
+    private void count(long started)
+    {
+        // avoid the annoying mock of the meterRegistry for unit tests
+        if (meterRegistry != null)
+        {
+            meterRegistry.counter("rabbit.listener.event", "listener", getClass().getSimpleName()).increment();
+            long duration = System.currentTimeMillis() - started;
+            meterRegistry.counter("rabbit.listener.event.total.duration.milliseconds", "listener", getClass().getSimpleName()).increment(duration);
+        }
+    }
+}

--- a/src/main/java/com/avides/spring/rabbit/listener/AbstractSpringRabbitListener.java
+++ b/src/main/java/com/avides/spring/rabbit/listener/AbstractSpringRabbitListener.java
@@ -70,7 +70,7 @@ public abstract class AbstractSpringRabbitListener<T> implements SpringRabbitLis
         // avoid the annoying mock of the meterRegistry for unit tests
         if (meterRegistry != null)
         {
-            var appId = StringUtils.hasText(messageProperties.getAppId()) ? messageProperties.getAppId() : "";
+            var appId = StringUtils.hasText(messageProperties.getAppId()) ? messageProperties.getAppId() : "UNKNOWN";
             var tags = Tags.of(Tag.of("listener", getClass().getSimpleName()), Tag.of("from", appId));
             meterRegistry.counter("rabbit.listener.event", tags).increment();
             long duration = System.currentTimeMillis() - started;

--- a/src/main/java/com/avides/spring/rabbit/listener/AbstractSpringRabbitListener.java
+++ b/src/main/java/com/avides/spring/rabbit/listener/AbstractSpringRabbitListener.java
@@ -13,6 +13,8 @@ import io.micrometer.core.instrument.Tags;
  * Abstract implementation of {@link SpringRabbitListener} with metrics.
  * <p>
  * Implementing classes shall either override {@link #handleEvent(Object)} or {@link #handleEvent(Object, MessageProperties)}.
+ *
+ * @param <T> expected type of the incoming object
  */
 public abstract class AbstractSpringRabbitListener<T> implements SpringRabbitListener<T>
 {

--- a/src/main/java/com/avides/spring/rabbit/listener/AbstractSpringRabbitListener.java
+++ b/src/main/java/com/avides/spring/rabbit/listener/AbstractSpringRabbitListener.java
@@ -70,11 +70,8 @@ public abstract class AbstractSpringRabbitListener<T> implements SpringRabbitLis
         // avoid the annoying mock of the meterRegistry for unit tests
         if (meterRegistry != null)
         {
-            var tags = Tags.of(Tag.of("listener", getClass().getSimpleName()));
-            if (messageProperties != null && StringUtils.hasText(messageProperties.getAppId()))
-            {
-                tags = tags.and(Tag.of("from", messageProperties.getAppId()));
-            }
+            var appId = StringUtils.hasText(messageProperties.getAppId()) ? messageProperties.getAppId() : "";
+            var tags = Tags.of(Tag.of("listener", getClass().getSimpleName()), Tag.of("from", appId));
             meterRegistry.counter("rabbit.listener.event", tags).increment();
             long duration = System.currentTimeMillis() - started;
             meterRegistry.counter("rabbit.listener.event.total.duration.milliseconds", tags).increment(duration);

--- a/src/main/java/com/avides/spring/rabbit/listener/ContextAwareRabbitListener.java
+++ b/src/main/java/com/avides/spring/rabbit/listener/ContextAwareRabbitListener.java
@@ -4,10 +4,7 @@ import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.function.Supplier;
 
-import javax.validation.Valid;
-
 import org.springframework.amqp.core.MessageProperties;
-import org.springframework.amqp.support.converter.MessageConverter;
 import org.springframework.validation.annotation.Validated;
 
 import com.avides.spring.rabbit.converter.SpringRabbitMessageConverter;
@@ -17,18 +14,12 @@ import com.avides.spring.rabbit.converter.SpringRabbitMessageConverter;
  *
  * @see RabbitListener
  * @param <T> expected type of the incoming object
+ * @deprecated use {@link SpringRabbitListener}, will be deleted soon
  */
 @Validated
-public interface ContextAwareRabbitListener<T>
+@Deprecated(forRemoval = true)
+public interface ContextAwareRabbitListener<T> extends SpringRabbitListener<T>
 {
-    /**
-     * Called by an incoming message after the message got unmarshaled by a {@link MessageConverter}
-     *
-     * @param object the incoming object
-     * @param messageProperties the message properties of the message
-     */
-    void handle(@Valid T object, MessageProperties messageProperties);
-
     /**
      * Helper method to simplify the tests
      * <p>
@@ -64,6 +55,7 @@ public interface ContextAwareRabbitListener<T>
      *
      * @return the class of the generic type
      */
+    @Override
     @SuppressWarnings("unchecked")
     default Class<T> getGenericTypeClass()
     {

--- a/src/main/java/com/avides/spring/rabbit/listener/CountingContextAwareRabbitListener.java
+++ b/src/main/java/com/avides/spring/rabbit/listener/CountingContextAwareRabbitListener.java
@@ -2,6 +2,11 @@ package com.avides.spring.rabbit.listener;
 
 import org.springframework.amqp.core.MessageProperties;
 
+/**
+ * @deprecated use {@link AbstractSpringRabbitListener}, will be removed soon
+ * @param <T> type of unmarshaled object
+ */
+@Deprecated(forRemoval = true)
 public abstract class CountingContextAwareRabbitListener<T> extends AbstractCountingRabbitListener implements ContextAwareRabbitListener<T>
 {
     @Override

--- a/src/main/java/com/avides/spring/rabbit/listener/CountingRabbitListener.java
+++ b/src/main/java/com/avides/spring/rabbit/listener/CountingRabbitListener.java
@@ -1,5 +1,10 @@
 package com.avides.spring.rabbit.listener;
 
+/**
+ * @deprecated use {@link AbstractSpringRabbitListener}, will be removed soon
+ * @param <T> type of unmarshaled object
+ */
+@Deprecated(forRemoval = true)
 public abstract class CountingRabbitListener<T> extends AbstractCountingRabbitListener implements RabbitListener<T>
 {
     @Override

--- a/src/main/java/com/avides/spring/rabbit/listener/RabbitListener.java
+++ b/src/main/java/com/avides/spring/rabbit/listener/RabbitListener.java
@@ -17,8 +17,10 @@ import com.avides.spring.rabbit.converter.SpringRabbitMessageConverter;
  * After the message got unmarshaled, the object will be validated
  *
  * @param <T> expected type of the incoming object
+ * @deprecated use {@link SpringRabbitListener}, will be deleted soon
  */
 @Validated
+@Deprecated(forRemoval = true)
 public interface RabbitListener<T>
 {
     /**

--- a/src/main/java/com/avides/spring/rabbit/listener/RequestResponseRabbitListener.java
+++ b/src/main/java/com/avides/spring/rabbit/listener/RequestResponseRabbitListener.java
@@ -4,6 +4,7 @@ import org.springframework.amqp.core.MessageProperties;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.util.Assert;
 
+// TODO RequestResponseSpringRabbitListener???
 public abstract class RequestResponseRabbitListener<T> extends CountingContextAwareRabbitListener<T>
 {
     private RabbitTemplate responseRabbitTemplate;

--- a/src/main/java/com/avides/spring/rabbit/listener/RequestResponseRabbitListener.java
+++ b/src/main/java/com/avides/spring/rabbit/listener/RequestResponseRabbitListener.java
@@ -4,16 +4,40 @@ import org.springframework.amqp.core.MessageProperties;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.util.Assert;
 
-// TODO RequestResponseSpringRabbitListener???
-public abstract class RequestResponseRabbitListener<T> extends CountingContextAwareRabbitListener<T>
+/**
+ * Abstract implementation of {@link SpringRabbitListener} with metrics to handle request messages and produce corresponding response messages.
+ *
+ * @param <T> expected type of the incoming object
+ */
+public abstract class RequestResponseRabbitListener<T> extends AbstractSpringRabbitListener<T>
 {
     private RabbitTemplate responseRabbitTemplate;
 
+    /**
+     * Constructs a new {@link RequestResponseRabbitListener} with the given {@link RabbitTemplate} for responses.
+     *
+     * @param responseRabbitTemplate used for response messages
+     */
     public RequestResponseRabbitListener(RabbitTemplate responseRabbitTemplate)
     {
         this.responseRabbitTemplate = responseRabbitTemplate;
     }
 
+    /**
+     * Processes unmarshaled request message and returns the (not yet marshaled) response message.
+     *
+     * @param requestObject unmarshaled request message
+     * @return response message (not yet marshaled)
+     */
+    protected abstract Object processRequest(T requestObject);
+
+    /**
+     * Handles given unmarshaled message with its properties and sends a response message. Called by {@link #handle(Object, MessageProperties)} which also
+     * collects some metrics. Calls {@link #processRequest(Object)} by default which must be overridden.
+     *
+     * @param requestObject the unmarshaled object
+     * @param messageProperties the message properties
+     */
     @Override
     protected void handleEvent(T requestObject, MessageProperties messageProperties)
     {
@@ -34,6 +58,4 @@ public abstract class RequestResponseRabbitListener<T> extends CountingContextAw
             });
         }
     }
-
-    protected abstract Object processRequest(T requestObject);
 }

--- a/src/main/java/com/avides/spring/rabbit/listener/RequestResponseSpringRabbitListener.java
+++ b/src/main/java/com/avides/spring/rabbit/listener/RequestResponseSpringRabbitListener.java
@@ -9,16 +9,16 @@ import org.springframework.util.Assert;
  *
  * @param <T> expected type of the incoming object
  */
-public abstract class RequestResponseRabbitListener<T> extends AbstractSpringRabbitListener<T>
+public abstract class RequestResponseSpringRabbitListener<T> extends AbstractSpringRabbitListener<T>
 {
     private RabbitTemplate responseRabbitTemplate;
 
     /**
-     * Constructs a new {@link RequestResponseRabbitListener} with the given {@link RabbitTemplate} for responses.
+     * Constructs a new {@link RequestResponseSpringRabbitListener} with the given {@link RabbitTemplate} for responses.
      *
      * @param responseRabbitTemplate used for response messages
      */
-    public RequestResponseRabbitListener(RabbitTemplate responseRabbitTemplate)
+    public RequestResponseSpringRabbitListener(RabbitTemplate responseRabbitTemplate)
     {
         this.responseRabbitTemplate = responseRabbitTemplate;
     }

--- a/src/main/java/com/avides/spring/rabbit/listener/SpringRabbitListener.java
+++ b/src/main/java/com/avides/spring/rabbit/listener/SpringRabbitListener.java
@@ -1,0 +1,44 @@
+package com.avides.spring.rabbit.listener;
+
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+
+import javax.validation.Valid;
+
+import org.springframework.amqp.core.MessageProperties;
+import org.springframework.amqp.support.converter.MessageConverter;
+import org.springframework.validation.annotation.Validated;
+
+import com.avides.spring.rabbit.converter.SpringRabbitMessageConverter;
+
+/**
+ * Handles unmarshaled RabbitMQ messages with the option to access the {@link MessageProperties}. Unmarshaled messages are validated.
+ *
+ * @param <T> expected type of the incoming object
+ */
+@Validated
+public interface SpringRabbitListener<T>
+{
+    /**
+     * Called by an incoming message after the message got unmarshaled by a {@link MessageConverter}.
+     *
+     * @param object the incoming object
+     * @param messageProperties the message properties of the message
+     */
+    void handle(@Valid T object, MessageProperties messageProperties);
+
+    /**
+     * Helper method to resolve the class of the generic type.
+     * <p>
+     * Shall not be used by developer directly! Currently used for the {@link SpringRabbitMessageConverter}.
+     *
+     * @return the class of the generic type
+     */
+    @SuppressWarnings("unchecked")
+    default Class<T> getGenericTypeClass()
+    {
+        Type type = getClass().getGenericSuperclass();
+        ParameterizedType paramType = (ParameterizedType) type;
+        return (Class<T>) paramType.getActualTypeArguments()[0];
+    }
+}

--- a/src/test/java/com/avides/spring/rabbit/listener/AbstractSpringRabbitListenerTest.java
+++ b/src/test/java/com/avides/spring/rabbit/listener/AbstractSpringRabbitListenerTest.java
@@ -1,0 +1,63 @@
+package com.avides.spring.rabbit.listener;
+
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.mock;
+import static org.powermock.api.easymock.PowerMock.replayAll;
+import static org.powermock.api.easymock.PowerMock.verifyAll;
+
+import org.easymock.TestSubject;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.api.easymock.annotation.MockStrict;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.springframework.amqp.core.MessageProperties;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.Tags;
+
+@RunWith(PowerMockRunner.class)
+public class AbstractSpringRabbitListenerTest
+{
+    @TestSubject
+    private SpringRabbitListener<Object> rabbitListener = new ImplementedSpringRabbitListener();
+
+    @MockStrict
+    private MeterRegistry meterRegistry;
+
+    @Test
+    public void testHandle()
+    {
+        Tags tags = Tags.of(Tag.of("listener", "ImplementedSpringRabbitListener"), Tag.of("from", "sender-app"));
+        expect(meterRegistry.counter("rabbit.listener.event", tags)).andReturn(mock(Counter.class));
+        expect(meterRegistry.counter("rabbit.listener.event.total.duration.milliseconds", tags)).andReturn(mock(Counter.class));
+
+        replayAll();
+        var messageProperties = new MessageProperties();
+        messageProperties.setAppId("sender-app");
+        rabbitListener.handle("hello", messageProperties);
+        verifyAll();
+    }
+
+    @Test
+    public void testHandleWithMessagePropertiesIsNull()
+    {
+        Tags tags = Tags.of(Tag.of("listener", "ImplementedSpringRabbitListener"));
+        expect(meterRegistry.counter("rabbit.listener.event", tags)).andReturn(mock(Counter.class));
+        expect(meterRegistry.counter("rabbit.listener.event.total.duration.milliseconds", tags)).andReturn(mock(Counter.class));
+
+        replayAll();
+        rabbitListener.handle("hello", null);
+        verifyAll();
+    }
+
+    private static class ImplementedSpringRabbitListener extends AbstractSpringRabbitListener<Object>
+    {
+        @Override
+        protected void handleEvent(Object object)
+        {
+            // not necessary
+        }
+    }
+}

--- a/src/test/java/com/avides/spring/rabbit/listener/AbstractSpringRabbitListenerTest.java
+++ b/src/test/java/com/avides/spring/rabbit/listener/AbstractSpringRabbitListenerTest.java
@@ -52,6 +52,18 @@ public class AbstractSpringRabbitListenerTest
         verifyAll();
     }
 
+    @Test
+    public void testHandleWithAppIdIsNull()
+    {
+        Tags tags = Tags.of(Tag.of("listener", "ImplementedSpringRabbitListener"));
+        expect(meterRegistry.counter("rabbit.listener.event", tags)).andReturn(mock(Counter.class));
+        expect(meterRegistry.counter("rabbit.listener.event.total.duration.milliseconds", tags)).andReturn(mock(Counter.class));
+
+        replayAll();
+        rabbitListener.handle("hello", new MessageProperties());
+        verifyAll();
+    }
+
     private static class ImplementedSpringRabbitListener extends AbstractSpringRabbitListener<Object>
     {
         @Override

--- a/src/test/java/com/avides/spring/rabbit/listener/AbstractSpringRabbitListenerTest.java
+++ b/src/test/java/com/avides/spring/rabbit/listener/AbstractSpringRabbitListenerTest.java
@@ -41,21 +41,9 @@ public class AbstractSpringRabbitListenerTest
     }
 
     @Test
-    public void testHandleWithMessagePropertiesIsNull()
-    {
-        Tags tags = Tags.of(Tag.of("listener", "ImplementedSpringRabbitListener"));
-        expect(meterRegistry.counter("rabbit.listener.event", tags)).andReturn(mock(Counter.class));
-        expect(meterRegistry.counter("rabbit.listener.event.total.duration.milliseconds", tags)).andReturn(mock(Counter.class));
-
-        replayAll();
-        rabbitListener.handle("hello", null);
-        verifyAll();
-    }
-
-    @Test
     public void testHandleWithAppIdIsNull()
     {
-        Tags tags = Tags.of(Tag.of("listener", "ImplementedSpringRabbitListener"));
+        Tags tags = Tags.of(Tag.of("listener", "ImplementedSpringRabbitListener"), Tag.of("from", ""));
         expect(meterRegistry.counter("rabbit.listener.event", tags)).andReturn(mock(Counter.class));
         expect(meterRegistry.counter("rabbit.listener.event.total.duration.milliseconds", tags)).andReturn(mock(Counter.class));
 

--- a/src/test/java/com/avides/spring/rabbit/listener/AbstractSpringRabbitListenerTest.java
+++ b/src/test/java/com/avides/spring/rabbit/listener/AbstractSpringRabbitListenerTest.java
@@ -43,7 +43,7 @@ public class AbstractSpringRabbitListenerTest
     @Test
     public void testHandleWithAppIdIsNull()
     {
-        Tags tags = Tags.of(Tag.of("listener", "ImplementedSpringRabbitListener"), Tag.of("from", ""));
+        Tags tags = Tags.of(Tag.of("listener", "ImplementedSpringRabbitListener"), Tag.of("from", "UNKNOWN"));
         expect(meterRegistry.counter("rabbit.listener.event", tags)).andReturn(mock(Counter.class));
         expect(meterRegistry.counter("rabbit.listener.event.total.duration.milliseconds", tags)).andReturn(mock(Counter.class));
 

--- a/src/test/java/com/avides/spring/rabbit/listener/RequestResponseSpringRabbitListenerTest.java
+++ b/src/test/java/com/avides/spring/rabbit/listener/RequestResponseSpringRabbitListenerTest.java
@@ -101,7 +101,7 @@ public class RequestResponseSpringRabbitListenerTest
     @Test
     public void testHandleEventWithoutResponseAndAppId()
     {
-        Tags tags = Tags.of(Tag.of("listener", "FailureRequestResponseSpringRabbitListener"));
+        Tags tags = Tags.of(Tag.of("listener", "FailureRequestResponseSpringRabbitListener"), Tag.of("from", ""));
 
         expect(meterRegistry.counter("rabbit.listener.event", tags)).andReturn(mock(Counter.class));
         expect(meterRegistry.counter("rabbit.listener.event.total.duration.milliseconds", tags)).andReturn(mock(Counter.class));
@@ -135,7 +135,7 @@ public class RequestResponseSpringRabbitListenerTest
     @Test
     public void testHandleEventWithoutAppId()
     {
-        Tags tags = Tags.of(Tag.of("listener", "SuccessRequestResponseSpringRabbitListener"));
+        Tags tags = Tags.of(Tag.of("listener", "SuccessRequestResponseSpringRabbitListener"), Tag.of("from", ""));
 
         responseRabbitTemplate.convertAndSend(eq(""), eq("response-queue"), eq("response"), EasyMock.anyObject(MessagePostProcessor.class));
         expect(meterRegistry.counter("rabbit.listener.event", tags)).andReturn(mock(Counter.class));

--- a/src/test/java/com/avides/spring/rabbit/listener/RequestResponseSpringRabbitListenerTest.java
+++ b/src/test/java/com/avides/spring/rabbit/listener/RequestResponseSpringRabbitListenerTest.java
@@ -101,7 +101,7 @@ public class RequestResponseSpringRabbitListenerTest
     @Test
     public void testHandleEventWithoutResponseAndAppId()
     {
-        Tags tags = Tags.of(Tag.of("listener", "FailureRequestResponseSpringRabbitListener"), Tag.of("from", ""));
+        Tags tags = Tags.of(Tag.of("listener", "FailureRequestResponseSpringRabbitListener"), Tag.of("from", "UNKNOWN"));
 
         expect(meterRegistry.counter("rabbit.listener.event", tags)).andReturn(mock(Counter.class));
         expect(meterRegistry.counter("rabbit.listener.event.total.duration.milliseconds", tags)).andReturn(mock(Counter.class));
@@ -135,7 +135,7 @@ public class RequestResponseSpringRabbitListenerTest
     @Test
     public void testHandleEventWithoutAppId()
     {
-        Tags tags = Tags.of(Tag.of("listener", "SuccessRequestResponseSpringRabbitListener"), Tag.of("from", ""));
+        Tags tags = Tags.of(Tag.of("listener", "SuccessRequestResponseSpringRabbitListener"), Tag.of("from", "UNKNOWN"));
 
         responseRabbitTemplate.convertAndSend(eq(""), eq("response-queue"), eq("response"), EasyMock.anyObject(MessagePostProcessor.class));
         expect(meterRegistry.counter("rabbit.listener.event", tags)).andReturn(mock(Counter.class));

--- a/src/test/java/com/avides/spring/rabbit/listener/RequestResponseSpringRabbitListenerTest.java
+++ b/src/test/java/com/avides/spring/rabbit/listener/RequestResponseSpringRabbitListenerTest.java
@@ -27,11 +27,11 @@ import io.micrometer.core.instrument.Tags;
 
 @RunWith(PowerMockRunner.class)
 @PowerMockIgnore("javax.management.*")
-public class RequestResponseRabbitListenerTest
+public class RequestResponseSpringRabbitListenerTest
 {
-    private RequestResponseRabbitListener<Object> successRabbitListener;
+    private RequestResponseSpringRabbitListener<Object> successRabbitListener;
 
-    private RequestResponseRabbitListener<Object> failureRabbitListener;
+    private RequestResponseSpringRabbitListener<Object> failureRabbitListener;
 
     @MockStrict
     private RabbitTemplate responseRabbitTemplate;
@@ -42,10 +42,10 @@ public class RequestResponseRabbitListenerTest
     @Before
     public void setup()
     {
-        successRabbitListener = new SuccessRequestResponseRabbitListener();
+        successRabbitListener = new SuccessRequestResponseSpringRabbitListener();
         Whitebox.setInternalState(successRabbitListener, meterRegistry);
 
-        failureRabbitListener = new FailureRequestResponseRabbitListener();
+        failureRabbitListener = new FailureRequestResponseSpringRabbitListener();
         Whitebox.setInternalState(failureRabbitListener, meterRegistry);
     }
 
@@ -84,7 +84,7 @@ public class RequestResponseRabbitListenerTest
     @Test
     public void testHandleEventWithoutResponse()
     {
-        Tags tags = Tags.of(Tag.of("listener", "FailureRequestResponseRabbitListener"), Tag.of("from", "sender-app"));
+        Tags tags = Tags.of(Tag.of("listener", "FailureRequestResponseSpringRabbitListener"), Tag.of("from", "sender-app"));
 
         expect(meterRegistry.counter("rabbit.listener.event", tags)).andReturn(mock(Counter.class));
         expect(meterRegistry.counter("rabbit.listener.event.total.duration.milliseconds", tags)).andReturn(mock(Counter.class));
@@ -101,7 +101,7 @@ public class RequestResponseRabbitListenerTest
     @Test
     public void testHandleEventWithoutResponseAndAppId()
     {
-        Tags tags = Tags.of(Tag.of("listener", "FailureRequestResponseRabbitListener"));
+        Tags tags = Tags.of(Tag.of("listener", "FailureRequestResponseSpringRabbitListener"));
 
         expect(meterRegistry.counter("rabbit.listener.event", tags)).andReturn(mock(Counter.class));
         expect(meterRegistry.counter("rabbit.listener.event.total.duration.milliseconds", tags)).andReturn(mock(Counter.class));
@@ -117,7 +117,7 @@ public class RequestResponseRabbitListenerTest
     @Test
     public void testHandleEvent()
     {
-        Tags tags = Tags.of(Tag.of("listener", "SuccessRequestResponseRabbitListener"), Tag.of("from", "sender-app"));
+        Tags tags = Tags.of(Tag.of("listener", "SuccessRequestResponseSpringRabbitListener"), Tag.of("from", "sender-app"));
 
         responseRabbitTemplate.convertAndSend(eq(""), eq("response-queue"), eq("response"), EasyMock.anyObject(MessagePostProcessor.class));
         expect(meterRegistry.counter("rabbit.listener.event", tags)).andReturn(mock(Counter.class));
@@ -135,7 +135,7 @@ public class RequestResponseRabbitListenerTest
     @Test
     public void testHandleEventWithoutAppId()
     {
-        Tags tags = Tags.of(Tag.of("listener", "SuccessRequestResponseRabbitListener"));
+        Tags tags = Tags.of(Tag.of("listener", "SuccessRequestResponseSpringRabbitListener"));
 
         responseRabbitTemplate.convertAndSend(eq(""), eq("response-queue"), eq("response"), EasyMock.anyObject(MessagePostProcessor.class));
         expect(meterRegistry.counter("rabbit.listener.event", tags)).andReturn(mock(Counter.class));
@@ -149,9 +149,9 @@ public class RequestResponseRabbitListenerTest
         verifyAll();
     }
 
-    private class SuccessRequestResponseRabbitListener extends RequestResponseRabbitListener<Object>
+    private class SuccessRequestResponseSpringRabbitListener extends RequestResponseSpringRabbitListener<Object>
     {
-        public SuccessRequestResponseRabbitListener()
+        public SuccessRequestResponseSpringRabbitListener()
         {
             super(responseRabbitTemplate);
         }
@@ -163,9 +163,9 @@ public class RequestResponseRabbitListenerTest
         }
     }
 
-    private class FailureRequestResponseRabbitListener extends RequestResponseRabbitListener<Object>
+    private class FailureRequestResponseSpringRabbitListener extends RequestResponseSpringRabbitListener<Object>
     {
-        public FailureRequestResponseRabbitListener()
+        public FailureRequestResponseSpringRabbitListener()
         {
             super(responseRabbitTemplate);
         }

--- a/src/test/java/com/avides/spring/rabbit/listener/container/DefaultMessageListenerContainerTest.java
+++ b/src/test/java/com/avides/spring/rabbit/listener/container/DefaultMessageListenerContainerTest.java
@@ -1,5 +1,8 @@
 package com.avides.spring.rabbit.listener.container;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.powermock.api.easymock.annotation.Mock;
@@ -10,6 +13,7 @@ import org.springframework.amqp.support.converter.MessageConverter;
 
 import com.avides.spring.rabbit.listener.ContextAwareRabbitListener;
 import com.avides.spring.rabbit.listener.RabbitListener;
+import com.avides.spring.rabbit.listener.SpringRabbitListener;
 
 @RunWith(PowerMockRunner.class)
 @PowerMockIgnore("javax.management.*")
@@ -19,10 +23,15 @@ public class DefaultMessageListenerContainerTest
     private ConnectionFactory connectionFactory;
 
     @Mock
+    @Deprecated(forRemoval = true)
     private RabbitListener<Object> rabbitListener;
 
     @Mock
+    @Deprecated(forRemoval = true)
     private ContextAwareRabbitListener<Object> contextAwareRabbitListener;
+
+    @Mock
+    private SpringRabbitListener<Object> springRabbitListener;
 
     @Mock
     private MessageConverter messageConverter;
@@ -30,54 +39,91 @@ public class DefaultMessageListenerContainerTest
     @Test
     public void testConstructor()
     {
-        new DefaultMessageListenerContainer<>(connectionFactory);
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void testConstructorWithNull()
-    {
-        new DefaultMessageListenerContainer<>(null);
+        var listenerContainer = new DefaultMessageListenerContainer<>(connectionFactory);
+        assertThat(listenerContainer.getConnectionFactory()).isSameAs(connectionFactory);
     }
 
     @Test
+    public void testConstructorWithNull()
+    {
+        assertThatThrownBy(() -> new DefaultMessageListenerContainer<>(null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("connectionFactory must not be null");
+    }
+
+    @Test
+    public void testSetSpringRabbitListener()
+    {
+        var listenerContainer = new DefaultMessageListenerContainer<>(connectionFactory);
+        listenerContainer.setSpringRabbitListener(springRabbitListener, messageConverter);
+        assertThat(listenerContainer.getMessageListener()).isNotNull();
+    }
+
+    @Test
+    public void testSetSpringRabbitListenerWithoutListener()
+    {
+        var listenerContainer = new DefaultMessageListenerContainer<>(connectionFactory);
+        assertThatThrownBy(() -> listenerContainer.setSpringRabbitListener(null, messageConverter))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("springRabbitListener must not be null");
+    }
+
+    @Test
+    public void testSetSpringRabbitListenerWithoutMessageConverter()
+    {
+        var listenerContainer = new DefaultMessageListenerContainer<>(connectionFactory);
+        assertThatThrownBy(() -> listenerContainer.setSpringRabbitListener(springRabbitListener, null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("messageConverter must not be null");
+    }
+
+    @Test
+    @Deprecated(forRemoval = true)
     public void testSetListener()
     {
-        DefaultMessageListenerContainer<Object> listenerContainer = new DefaultMessageListenerContainer<>(connectionFactory);
+        var listenerContainer = new DefaultMessageListenerContainer<>(connectionFactory);
         listenerContainer.setListener(rabbitListener, messageConverter);
+        assertThat(listenerContainer.getMessageListener()).isNotNull();
     }
 
     @Test(expected = IllegalArgumentException.class)
+    @Deprecated(forRemoval = true)
     public void testSetListenerWithoutListener()
     {
-        DefaultMessageListenerContainer<Object> listenerContainer = new DefaultMessageListenerContainer<>(connectionFactory);
+        var listenerContainer = new DefaultMessageListenerContainer<>(connectionFactory);
         listenerContainer.setListener(null, messageConverter);
     }
 
     @Test(expected = IllegalArgumentException.class)
+    @Deprecated(forRemoval = true)
     public void testSetListenerWithoutMessageConverter()
     {
-        DefaultMessageListenerContainer<Object> listenerContainer = new DefaultMessageListenerContainer<>(connectionFactory);
+        var listenerContainer = new DefaultMessageListenerContainer<>(connectionFactory);
         listenerContainer.setListener(rabbitListener, null);
     }
 
     @Test
+    @Deprecated(forRemoval = true)
     public void testSetContextAwareListener()
     {
-        DefaultMessageListenerContainer<Object> listenerContainer = new DefaultMessageListenerContainer<>(connectionFactory);
+        var listenerContainer = new DefaultMessageListenerContainer<>(connectionFactory);
         listenerContainer.setContextAwareListener(contextAwareRabbitListener, messageConverter);
+        assertThat(listenerContainer.getMessageListener()).isNotNull();
     }
 
     @Test(expected = IllegalArgumentException.class)
+    @Deprecated(forRemoval = true)
     public void testSetContextAwareListenerWithoutListener()
     {
-        DefaultMessageListenerContainer<Object> listenerContainer = new DefaultMessageListenerContainer<>(connectionFactory);
+        var listenerContainer = new DefaultMessageListenerContainer<>(connectionFactory);
         listenerContainer.setContextAwareListener(null, messageConverter);
     }
 
     @Test(expected = IllegalArgumentException.class)
+    @Deprecated(forRemoval = true)
     public void testSetContextAwareListenerWithoutMessageConverter()
     {
-        DefaultMessageListenerContainer<Object> listenerContainer = new DefaultMessageListenerContainer<>(connectionFactory);
+        var listenerContainer = new DefaultMessageListenerContainer<>(connectionFactory);
         listenerContainer.setContextAwareListener(contextAwareRabbitListener, null);
     }
 }


### PR DESCRIPTION
For a generally valid solution to include the appId in the metrics, it was necessary to replace the previous listener interfaces/classes with a new one.

* Add `SpringRabbitListener`
* Add `AbstractSpringRabbitListener`
* Add `from`-tag with `appId` of producer
* Deprecate `RabbitListener`
* Deprecate `ContextAwareRabbitListener`
* Deprecate `AbstractCountingRabbitListener`
* Deprecate `CountingRabbitListener`
* Deprecate `CountingContextAwareRabbitListener`
* Rename `RequestResponseRabbitListener` to `RequestResponseSpringRabbitListener`
* Use `AbstractSpringRabbitListener` as base class for `RequestResponseSpringRabbitListener`
